### PR TITLE
Change to support set multiple locals, and some small change

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,7 @@ android {
         applicationId = "jp.co.c_lis.ccl.morelocale"
         namespace = "jp.co.c_lis.ccl.morelocale"
 
-        minSdk = 19
+        minSdk = 24
         maxSdk = 30
         targetSdk = 34
         multiDexEnabled = true

--- a/app/schemas/jp.co.c_lis.ccl.morelocale.AppDatabase/2.json
+++ b/app/schemas/jp.co.c_lis.ccl.morelocale.AppDatabase/2.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 2,
-    "identityHash": "760f2e4c0ae13c24aa786d9aec9ec9bf",
+    "identityHash": "7beb2ca6fc275344ad3eee1b08fdaadc",
     "entities": [
       {
         "tableName": "LocaleItem",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `label` TEXT, `language` TEXT, `country` TEXT, `variant` TEXT, `isPreset` INTEGER NOT NULL)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `label` TEXT, `language` TEXT, `country` TEXT, `variant` TEXT, `script` TEXT, `isPreset` INTEGER NOT NULL)",
         "fields": [
           {
             "fieldPath": "id",
@@ -39,6 +39,12 @@
             "notNull": false
           },
           {
+            "fieldPath": "script",
+            "columnName": "script",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
             "fieldPath": "isPreset",
             "columnName": "isPreset",
             "affinity": "INTEGER",
@@ -46,10 +52,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": true,
           "columnNames": [
             "id"
-          ],
-          "autoGenerate": true
+          ]
         },
         "indices": [],
         "foreignKeys": []
@@ -84,10 +90,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": true,
           "columnNames": [
             "id"
-          ],
-          "autoGenerate": true
+          ]
         },
         "indices": [],
         "foreignKeys": []
@@ -96,7 +102,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '760f2e4c0ae13c24aa786d9aec9ec9bf')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7beb2ca6fc275344ad3eee1b08fdaadc')"
     ]
   }
 }

--- a/app/src/androidTest/java/jp/co/c_lis/morelocale/RoomMigrationTest.kt
+++ b/app/src/androidTest/java/jp/co/c_lis/morelocale/RoomMigrationTest.kt
@@ -6,6 +6,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import jp.co.c_lis.ccl.morelocale.AppDatabase
 import jp.co.c_lis.ccl.morelocale.MIGRATION_1_2
+import jp.co.c_lis.ccl.morelocale.MIGRATION_2_3
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -31,5 +32,12 @@ class RoomMigrationTest {
     fun migrate1To2() {
         var db = helper.createDatabase(TEST_DB, 1)
         db = helper.runMigrationsAndValidate(TEST_DB, 2, true, MIGRATION_1_2)
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate2To3() {
+        var db = helper.createDatabase(TEST_DB, 2)
+        db = helper.runMigrationsAndValidate(TEST_DB, 3, true, MIGRATION_2_3)
     }
 }

--- a/app/src/main/java/jp/co/c_lis/ccl/morelocale/AppDatabase.kt
+++ b/app/src/main/java/jp/co/c_lis/ccl/morelocale/AppDatabase.kt
@@ -13,7 +13,7 @@ import jp.co.c_lis.ccl.morelocale.entity.LocaleItem
 
 @Database(
         entities = [LocaleItem::class, LocaleIsoItem::class],
-        version = 2
+        version = 3
 )
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
@@ -27,5 +27,12 @@ val MIGRATION_1_2 = object : Migration(1, 2) {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.execSQL("CREATE TABLE IF NOT EXISTS `LocaleIsoItem`" +
                 " (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT, `label` TEXT NOT NULL, `value` TEXT NOT NULL)")
+    }
+}
+
+val MIGRATION_2_3 = object : Migration(2, 3) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("DELETE FROM `LocaleItem`")
+        database.execSQL("ALTER TABLE `LocaleItem` ADD COLUMN `script` TEXT")
     }
 }

--- a/app/src/main/java/jp/co/c_lis/ccl/morelocale/LocaleUtil.kt
+++ b/app/src/main/java/jp/co/c_lis/ccl/morelocale/LocaleUtil.kt
@@ -1,8 +1,10 @@
 package jp.co.c_lis.ccl.morelocale
 
+import android.os.LocaleList
+import jp.co.c_lis.ccl.morelocale.entity.LocaleItem
 import java.util.Locale
 
-fun equals(obj1: Locale, obj2: Locale): Boolean {
+private fun equals(obj1: Locale, obj2: Locale): Boolean {
     if (obj1 === obj2) {
         return true
     }
@@ -19,5 +21,18 @@ fun equals(obj1: Locale, obj2: Locale): Boolean {
         return false
     }
 
+    return true
+}
+
+fun equals(obj1: LocaleList, obj2: LocaleList): Boolean {
+    if (obj1.size() != obj2.size()) {
+        return false
+    } else {
+        for (i in 0 until obj1.size()) {
+            if (!equals(obj1[i], obj2[i])) {
+                return false
+            }
+        }
+    }
     return true
 }

--- a/app/src/main/java/jp/co/c_lis/ccl/morelocale/LocaleUtil.kt
+++ b/app/src/main/java/jp/co/c_lis/ccl/morelocale/LocaleUtil.kt
@@ -21,6 +21,10 @@ private fun equals(obj1: Locale, obj2: Locale): Boolean {
         return false
     }
 
+    if (obj1.script != obj2.script) {
+        return false
+    }
+
     return true
 }
 

--- a/app/src/main/java/jp/co/c_lis/ccl/morelocale/MainApplication.kt
+++ b/app/src/main/java/jp/co/c_lis/ccl/morelocale/MainApplication.kt
@@ -26,6 +26,7 @@ class MainApplication : MultiDexApplication() {
                     BuildConfig.DATABASE_FILE_NAME
             )
                     .addMigrations(MIGRATION_1_2)
+                    .addMigrations(MIGRATION_2_3)
                     .build().also {
                         db = it
                     }

--- a/app/src/main/java/jp/co/c_lis/ccl/morelocale/entity/LocaleItem.kt
+++ b/app/src/main/java/jp/co/c_lis/ccl/morelocale/entity/LocaleItem.kt
@@ -57,7 +57,7 @@ data class LocaleItem(
 
     @IgnoredOnParcel
     @Ignore
-    val langCode = locale.toString()
+    val langCode: String = locale.toLanguageTag()
 
     val displayFull: String
         get() {
@@ -84,7 +84,8 @@ fun createLocale(locale: Locale, locales: List<LocaleItem>, ids: Set<Int>): Loca
             id = id,
             language = locale.language,
             country = locale.country,
-            variant = locale.variant
+            variant = locale.variant,
+            script = locale.script
         )
     }
 }

--- a/app/src/main/java/jp/co/c_lis/ccl/morelocale/entity/LocaleItem.kt
+++ b/app/src/main/java/jp/co/c_lis/ccl/morelocale/entity/LocaleItem.kt
@@ -8,6 +8,7 @@ import androidx.room.PrimaryKey
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import java.util.Locale
+import kotlin.random.Random
 
 @Parcelize
 @Entity
@@ -30,6 +31,14 @@ data class LocaleItem(
                 return oldItem.isPreset == newItem.isPreset
             }
         }
+
+        fun from(locale: Locale) {
+            LocaleItem(
+                language = locale.language,
+                country = locale.country,
+                variant = locale.variant
+            )
+        }
     }
 
     @IgnoredOnParcel
@@ -49,9 +58,14 @@ data class LocaleItem(
 
     val displayFull: String
         get() {
-            val language = language ?: "N/A"
-            val variant = variant ?: "N/A"
-            return "$displayName $language $country $variant"
+            fun defaultValue(value: String?): String {
+                return if (value.isNullOrEmpty()) "_" else value
+            }
+
+            val language = defaultValue(language)
+            val country = defaultValue(country)
+            val variant = defaultValue(variant)
+            return "$displayName ($language-$country-$variant)"
         }
 }
 
@@ -61,15 +75,18 @@ fun createLocale(localeStr: String): LocaleItem {
         0 -> {
             LocaleItem(language = localeStr)
         }
+
         1 -> {
             LocaleItem(language = localeTokens[0])
         }
+
         2 -> {
             LocaleItem(
                 language = localeTokens[0],
                 country = localeTokens[1]
             )
         }
+
         else -> {
             LocaleItem(
                 language = localeTokens[0],
@@ -80,10 +97,25 @@ fun createLocale(localeStr: String): LocaleItem {
     }
 }
 
-fun createLocale(locale: Locale): LocaleItem {
-    return LocaleItem(
-        language = locale.language,
-        country = locale.country,
-        variant = locale.variant
-    )
+fun createLocale(locale: Locale, locales: List<LocaleItem>, ids: Set<Int>): LocaleItem {
+    val firstOrNull = locales.firstOrNull {
+        (it.language ?: "") == locale.language &&
+                (it.country ?: "") == locale.country &&
+                (it.variant ?: "") == locale.variant
+    }
+    return if (firstOrNull != null) {
+        firstOrNull
+    } else {
+        var id: Int
+        do {
+            id = Random.nextInt()
+        } while (ids.contains(id))
+        
+        LocaleItem(
+            id = id,
+            language = locale.language,
+            country = locale.country,
+            variant = locale.variant
+        )
+    }
 }

--- a/app/src/main/java/jp/co/c_lis/ccl/morelocale/receiver/BootCompletedReceiver.kt
+++ b/app/src/main/java/jp/co/c_lis/ccl/morelocale/receiver/BootCompletedReceiver.kt
@@ -24,7 +24,7 @@ class BootCompletedReceiver : BroadcastReceiver() {
 
         runBlocking {
             val currentLocale = MoreLocale.getLocale(context.resources.configuration)
-            val savedLocale = PreferenceRepository(context).loadLocale()?.locale
+            val savedLocale = PreferenceRepository(context).loadLocale()
                     ?: return@runBlocking
 
             if (equals(currentLocale, savedLocale)) {

--- a/app/src/main/java/jp/co/c_lis/ccl/morelocale/repository/LocaleRepository.kt
+++ b/app/src/main/java/jp/co/c_lis/ccl/morelocale/repository/LocaleRepository.kt
@@ -1,7 +1,6 @@
 package jp.co.c_lis.ccl.morelocale.repository
 
 import android.content.Context
-import android.content.res.AssetManager
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -18,14 +17,13 @@ class LocaleRepository(applicationContext: Context) {
 
     private val db = MainApplication.getDbInstance(applicationContext)
 
-    suspend fun getAll(assetManager: AssetManager) = withContext(Dispatchers.IO) {
+    suspend fun getAll() = withContext(Dispatchers.IO) {
         val localeList = findAll()
         if (localeList.isNotEmpty()) {
             return@withContext localeList
         }
 
         val localeItems = Locale.getAvailableLocales()
-//assetManager.locales
             .filterNotNull()
             .reversed()
             .map { LocaleItem.from(it).also { it.isPreset = true } }

--- a/app/src/main/java/jp/co/c_lis/ccl/morelocale/repository/LocaleRepository.kt
+++ b/app/src/main/java/jp/co/c_lis/ccl/morelocale/repository/LocaleRepository.kt
@@ -9,9 +9,9 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import jp.co.c_lis.ccl.morelocale.MainApplication
 import jp.co.c_lis.ccl.morelocale.entity.LocaleItem
-import jp.co.c_lis.ccl.morelocale.entity.createLocale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.util.Locale
 import javax.inject.Singleton
 
 class LocaleRepository(applicationContext: Context) {
@@ -24,12 +24,13 @@ class LocaleRepository(applicationContext: Context) {
             return@withContext localeList
         }
 
-        val localeItems = assetManager.locales
-                .filterNotNull()
-                .reversed()
-                .map { localeStr -> createLocale(localeStr).also { it.isPreset = true } }
+        val localeItems = Locale.getAvailableLocales()
+//assetManager.locales
+            .filterNotNull()
+            .reversed()
+            .map { LocaleItem.from(it).also { it.isPreset = true } }
         db.localeItemDao()
-                .insertAll(localeItems)
+            .insertAll(localeItems)
 
         return@withContext findAll()
     }
@@ -40,17 +41,17 @@ class LocaleRepository(applicationContext: Context) {
 
     suspend fun create(locale: LocaleItem) = withContext(Dispatchers.IO) {
         db.localeItemDao()
-                .insert(locale)
+            .insert(locale)
     }
 
     suspend fun update(locale: LocaleItem) = withContext(Dispatchers.IO) {
         db.localeItemDao()
-                .update(locale)
+            .update(locale)
     }
 
     suspend fun delete(locale: LocaleItem) = withContext(Dispatchers.IO) {
         db.localeItemDao()
-                .delete(locale)
+            .delete(locale)
     }
 }
 

--- a/app/src/main/java/jp/co/c_lis/ccl/morelocale/repository/PreferenceRepository.kt
+++ b/app/src/main/java/jp/co/c_lis/ccl/morelocale/repository/PreferenceRepository.kt
@@ -26,8 +26,7 @@ class PreferenceRepository(applicationContext: Context) {
     suspend fun saveLocale(locales: LocaleList) = withContext(Dispatchers.IO) {
         val ls = mutableListOf<String>()
         for (i in 0 until locales.size()) {
-            val e = locales[i]
-            ls.add("${e.language}-${e.country}-${e.variant}")
+            ls.add(locales[i].toString())
         }
 
         pref.edit()
@@ -40,15 +39,18 @@ class PreferenceRepository(applicationContext: Context) {
         val locals = store.split(';')
 
         return@withContext locals.map {
-            val locale = it.split('-')
-            val language = locale[0]
-            val country = locale[1]
-            val variant = locale[2]
+            val locale = it.split('_')
+            val language = if (locale.isNotEmpty()) locale[0] else null
+            val country = if (locale.size > 1) locale[1] else null
+            val variantAndScript = if (locale.size > 2) locale[2].split('#') else listOf()
+            val variant = if (variantAndScript.isNotEmpty()) variantAndScript[0] else null
+            val script = if (variantAndScript.size > 1) variantAndScript[1] else null
 
             LocaleItem(
                 language = language,
                 country = country,
-                variant = variant
+                variant = variant,
+                script = script
             ).locale
         }.let {
             LocaleList(*it.toTypedArray())

--- a/app/src/main/java/jp/co/c_lis/ccl/morelocale/repository/PreferenceRepository.kt
+++ b/app/src/main/java/jp/co/c_lis/ccl/morelocale/repository/PreferenceRepository.kt
@@ -8,15 +8,18 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import jp.co.c_lis.ccl.morelocale.BuildConfig
-import jp.co.c_lis.ccl.morelocale.entity.LocaleItem
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.util.Locale
 import javax.inject.Singleton
 
 class PreferenceRepository(applicationContext: Context) {
 
     companion object {
-        private const val KEY_LANGUAGE = "key_language"
+        @Deprecated("don't use anymore") private const val KEY_LANGUAGE = "key_language"
+        @Deprecated("don't use anymore") private const val KEY_COUNTRY = "key_country"
+        @Deprecated("don't use anymore") private const val KEY_VARIANT = "key_variant"
+        private const val KEY_LANGUAGES = "key_languages"
     }
 
     private val pref = applicationContext.getSharedPreferences(
@@ -24,42 +27,23 @@ class PreferenceRepository(applicationContext: Context) {
     )
 
     suspend fun saveLocale(locales: LocaleList) = withContext(Dispatchers.IO) {
-        val ls = mutableListOf<String>()
-        for (i in 0 until locales.size()) {
-            ls.add(locales[i].toString())
-        }
-
         pref.edit()
-            .putString(KEY_LANGUAGE, ls.joinToString(";"))
+            .putString(KEY_LANGUAGES, locales.toLanguageTags())
             .commit()
     }
 
     suspend fun loadLocale() = withContext(Dispatchers.IO) {
-        val store = pref.getString(KEY_LANGUAGE, null) ?: return@withContext null
-        val locals = store.split(';')
-
-        return@withContext locals.map {
-            val locale = it.split('_')
-            val language = if (locale.isNotEmpty()) locale[0] else null
-            val country = if (locale.size > 1) locale[1] else null
-            val variantAndScript = if (locale.size > 2) locale[2].split('#') else listOf()
-            val variant = if (variantAndScript.isNotEmpty()) variantAndScript[0] else null
-            val script = if (variantAndScript.size > 1) variantAndScript[1] else null
-
-            LocaleItem(
-                language = language,
-                country = country,
-                variant = variant,
-                script = script
-            ).locale
-        }.let {
-            LocaleList(*it.toTypedArray())
-        }
+        val store = pref.getString(KEY_LANGUAGES, null) ?: return@withContext null
+        return@withContext LocaleList.forLanguageTags(store)
     }
 
+    @Suppress("DEPRECATION")
     fun clearLocale() {
         pref.edit()
             .putString(KEY_LANGUAGE, null)
+            .putString(KEY_COUNTRY, null)
+            .putString(KEY_VARIANT, null)
+            .putString(KEY_LANGUAGES, null)
             .apply()
     }
 }

--- a/app/src/main/java/jp/co/c_lis/ccl/morelocale/service/RestoreLocaleService.kt
+++ b/app/src/main/java/jp/co/c_lis/ccl/morelocale/service/RestoreLocaleService.kt
@@ -10,6 +10,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.IBinder
+import android.os.LocaleList
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.PendingIntentCompat
@@ -120,7 +121,7 @@ class RestoreLocaleService : Service() {
         val currentLocale = MoreLocale.getLocale(resources.configuration)
 
         val locale = runBlocking {
-            preferenceRepository.loadLocale()?.locale
+            preferenceRepository.loadLocale()
         } ?: return START_STICKY_COMPATIBILITY
 
         if (equals(currentLocale, locale)) {
@@ -195,11 +196,11 @@ class RestoreLocaleService : Service() {
         coroutineScope.cancel()
     }
 
-    private fun restoreLocale(locale: Locale): Boolean {
+    private fun restoreLocale(locales: LocaleList): Boolean {
         Timber.d("Restore locale")
 
         try {
-            MoreLocale.setLocale(locale)
+            MoreLocale.setLocale(locales)
             return true
         } catch (e: InvocationTargetException) {
             Timber.e(e)

--- a/app/src/main/java/jp/co/c_lis/ccl/morelocale/ui/help/HowToUsePmCommandDialog.kt
+++ b/app/src/main/java/jp/co/c_lis/ccl/morelocale/ui/help/HowToUsePmCommandDialog.kt
@@ -2,6 +2,9 @@ package jp.co.c_lis.ccl.morelocale.ui.help
 
 import android.Manifest
 import android.app.Dialog
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -31,12 +34,22 @@ class HowToUsePmCommandDialog : AppCompatDialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
 
         return AlertDialog.Builder(requireContext())
-                .setTitle(R.string.use_pm_command)
-                .setMessage(R.string.use_pm_command_message)
-                .create()
+            .setTitle(R.string.use_pm_command)
+            .setMessage(R.string.use_pm_command_message)
+            .setPositiveButton(R.string.click_to_copy_the_command) { _, _ ->
+                val context = requireContext()
+                val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager?
+                clipboard?.setPrimaryClip(ClipData.newPlainText("command", "adb shell pm grant ${context.packageName} android.permission.CHANGE_CONFIGURATION"))
+                Toast.makeText(context, R.string.already_copy_the_command, Toast.LENGTH_SHORT).show()
+            }
+            .create()
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View? {
         startCheckJob()
 
         return super.onCreateView(inflater, container, savedInstanceState)
@@ -49,9 +62,14 @@ class HowToUsePmCommandDialog : AppCompatDialogFragment() {
             while (true) {
                 delay(INTERVAL_CHECK_PERMISSION)
 
-                if (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.CHANGE_CONFIGURATION)
-                        == PackageManager.PERMISSION_GRANTED) {
-                    Toast.makeText(requireContext(), R.string.permission_granted, Toast.LENGTH_LONG).show()
+                if (ContextCompat.checkSelfPermission(
+                        requireContext(),
+                        Manifest.permission.CHANGE_CONFIGURATION
+                    )
+                    == PackageManager.PERMISSION_GRANTED
+                ) {
+                    Toast.makeText(requireContext(), R.string.permission_granted, Toast.LENGTH_LONG)
+                        .show()
                     dismiss()
                 }
             }

--- a/app/src/main/java/jp/co/c_lis/ccl/morelocale/ui/help/PermissionRequiredDialog.kt
+++ b/app/src/main/java/jp/co/c_lis/ccl/morelocale/ui/help/PermissionRequiredDialog.kt
@@ -1,7 +1,10 @@
 package jp.co.c_lis.ccl.morelocale.ui.help
 
 import android.app.Dialog
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
+import android.provider.Settings
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatDialogFragment
@@ -20,7 +23,8 @@ class PermissionRequiredDialog : AppCompatDialogFragment() {
         val TAG = PermissionRequiredDialog::class.simpleName
 
         private const val TIMEOUT = 15 * 1000
-        private const val COMMAND_PM_GRANT = "pm grant jp.co.c_lis.ccl.morelocale android.permission.CHANGE_CONFIGURATION"
+        private const val COMMAND_PM_GRANT =
+            "pm grant jp.co.c_lis.ccl.morelocale android.permission.CHANGE_CONFIGURATION"
 
         fun getInstance(): PermissionRequiredDialog {
             return PermissionRequiredDialog()
@@ -29,30 +33,48 @@ class PermissionRequiredDialog : AppCompatDialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
 
-        return AlertDialog.Builder(requireContext(), R.style.theme_permission_dialog)
-                .setTitle(R.string.permission_required)
-                .setMessage(R.string.permission_required_message)
-                .setPositiveButton(R.string.use_pm_command) { _, _ ->
-                    HowToUsePmCommandDialog.getInstance()
-                            .show(parentFragmentManager, HowToUsePmCommandDialog.TAG)
+        var dialog = AlertDialog.Builder(requireContext(), R.style.theme_permission_dialog)
+            .setTitle(R.string.permission_required)
+            .setPositiveButton(R.string.use_pm_command) { _, _ ->
+                HowToUsePmCommandDialog.getInstance()
+                    .show(parentFragmentManager, HowToUsePmCommandDialog.TAG)
+            }
+            .setNeutralButton(R.string.execute_as_su) { _, _ ->
+                if (getPermissionAsSuperUser()) {
+                    Toast.makeText(
+                        requireContext(),
+                        R.string.permission_granted, Toast.LENGTH_LONG
+                    ).show()
+                } else {
+                    Toast.makeText(
+                        requireContext(),
+                        R.string.could_not_get_su_privilege, Toast.LENGTH_LONG
+                    ).show()
                 }
-                .setNeutralButton(R.string.execute_as_su) { _, _ ->
-                    if (getPermissionAsSuperUser()) {
-                        Toast.makeText(requireContext(),
-                                R.string.permission_granted, Toast.LENGTH_LONG).show()
-                    } else {
-                        Toast.makeText(requireContext(),
-                                R.string.could_not_get_su_privilege, Toast.LENGTH_LONG).show()
-                    }
+            }
+        dialog = if (Settings.System.canWrite(context)) {
+            dialog.setMessage(R.string.permission_required_message)
+        } else {
+            dialog
+                .setMessage(R.string.permission_required_message_extra_permission)
+                .setNegativeButton(R.string.go_to_settings) { _, _ ->
+                    val context = requireContext()
+                    val intent = Intent(
+                        Settings.ACTION_MANAGE_WRITE_SETTINGS,
+                        Uri.parse("package:" + context.packageName)
+                    )
+                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    startActivity(intent)
                 }
-                .create()
+        }
+        return dialog.create()
     }
 
     private fun getPermissionAsSuperUser(): Boolean {
         try {
             RootTools.debugMode = BuildConfig.DEBUG
             RootTools.getShell(true, TIMEOUT)
-                    .add(Command(0, COMMAND_PM_GRANT))
+                .add(Command(0, COMMAND_PM_GRANT))
             return true
         } catch (e: RootDeniedException) {
             Timber.e(e)

--- a/app/src/main/java/jp/co/c_lis/ccl/morelocale/ui/locale_list/CurrentLocaleListAdapter.kt
+++ b/app/src/main/java/jp/co/c_lis/ccl/morelocale/ui/locale_list/CurrentLocaleListAdapter.kt
@@ -1,0 +1,85 @@
+package jp.co.c_lis.ccl.morelocale.ui.locale_list
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.widget.PopupMenu
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import jp.co.c_lis.ccl.morelocale.R
+import jp.co.c_lis.ccl.morelocale.databinding.ListItemLocaleBinding
+import jp.co.c_lis.ccl.morelocale.entity.LocaleItem
+
+class CurrentLocaleListAdapter(
+    private val inflater: LayoutInflater,
+    private val menuCallback: MenuCallback? = null,
+) : ListAdapter<LocaleItem, RecyclerView.ViewHolder>(LocaleItem.itemDiffCallback) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return LocaleItemViewHolder(
+            inflater.inflate(R.layout.list_item_locale, parent, false),
+            menuCallback
+        )
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        if (holder is LocaleItemViewHolder) {
+            holder.bind(getItem(position))
+        }
+    }
+
+    override fun onViewRecycled(holder: RecyclerView.ViewHolder) {
+        super.onViewRecycled(holder)
+        if (holder is LocaleItemViewHolder) {
+            holder.unbind()
+        }
+    }
+
+    class LocaleItemViewHolder(
+        itemView: View,
+        private val menuCallback: MenuCallback?,
+    ) : RecyclerView.ViewHolder(itemView) {
+        private val binding = ListItemLocaleBinding.bind(itemView)
+
+        fun bind(localeItem: LocaleItem) {
+            binding.locale = localeItem
+
+            binding.more.visibility = View.VISIBLE
+            binding.root.setOnLongClickListener {
+                showPopupMenu(binding.more, localeItem)
+                return@setOnLongClickListener true
+            }
+            binding.more.setOnClickListener {
+                showPopupMenu(it, localeItem)
+            }
+        }
+
+        private fun showPopupMenu(it: View, localeItem: LocaleItem) {
+            PopupMenu(itemView.context, it).also { popupMenu ->
+                popupMenu.menuInflater.inflate(
+                    R.menu.list_item_current_locale,
+                    popupMenu.menu
+                )
+                popupMenu.setOnMenuItemClickListener { menuItem ->
+                    when (menuItem.itemId) {
+                        R.id.menu_up -> menuCallback?.onMove(localeItem, true)
+                        R.id.menu_down -> menuCallback?.onMove(localeItem, false)
+                        R.id.menu_delete -> menuCallback?.onDelete(localeItem)
+                        R.id.menu_edit -> menuCallback?.onEdit(localeItem)
+                    }
+                    return@setOnMenuItemClickListener true
+                }
+            }.show()
+        }
+
+        fun unbind() {
+            binding.unbind()
+        }
+    }
+
+    interface MenuCallback {
+        fun onMove(localeItem: LocaleItem, isUp: Boolean)
+        fun onEdit(localeItem: LocaleItem)
+        fun onDelete(localeItem: LocaleItem)
+    }
+}

--- a/app/src/main/java/jp/co/c_lis/ccl/morelocale/ui/locale_list/LocaleListFragment.kt
+++ b/app/src/main/java/jp/co/c_lis/ccl/morelocale/ui/locale_list/LocaleListFragment.kt
@@ -41,26 +41,57 @@ class LocaleListFragment : Fragment(R.layout.fragment_locale_list) {
 
     private val menuCallback = object : LocaleListAdapter.MenuCallback {
         override fun onEdit(localeItem: LocaleItem) {
-            parentFragmentManager.beginTransaction()
-                    .setCustomAnimations(R.anim.fragment_in, R.anim.fragment_out, R.anim.fragment_in, R.anim.fragment_out)
-                    .add(R.id.fragment_container, EditLocaleFragment.getEditInstance(localeItem))
-                    .addToBackStack(null)
-                    .commit()
+            onEditLocale(localeItem)
         }
 
         override fun onDelete(localeItem: LocaleItem) {
             ConfirmDialog.show(
-                    targetFragment = this@LocaleListFragment,
-                    title = "",
-                    message = getString(R.string.confirm_delete),
-                    positiveButtonLabel = getString(R.string.delete),
-                    negativeButtonLabel = getString(android.R.string.cancel),
-                    onPositiveButtonClicked = { viewModel.deleteLocale(localeItem) },
+                targetFragment = this@LocaleListFragment,
+                title = "",
+                message = getString(R.string.confirm_delete),
+                positiveButtonLabel = getString(R.string.delete),
+                negativeButtonLabel = getString(android.R.string.cancel),
+                onPositiveButtonClicked = { viewModel.deleteLocale(localeItem) },
             )
         }
     }
 
+    private val currentListItemMenuCallback = object : CurrentLocaleListAdapter.MenuCallback {
+        override fun onMove(localeItem: LocaleItem, isUp: Boolean) {
+            viewModel.moveInCurrentLocales(localeItem, isUp)
+        }
+
+        override fun onEdit(localeItem: LocaleItem) {
+            onEditLocale(localeItem)
+        }
+
+        override fun onDelete(localeItem: LocaleItem) {
+            ConfirmDialog.show(
+                targetFragment = this@LocaleListFragment,
+                title = "",
+                message = getString(R.string.confirm_delete),
+                positiveButtonLabel = getString(R.string.delete),
+                negativeButtonLabel = getString(android.R.string.cancel),
+                onPositiveButtonClicked = { viewModel.delFromCurrentLocales(localeItem) },
+            )
+        }
+    }
+
+    private fun onEditLocale(localeItem: LocaleItem) {
+        parentFragmentManager.beginTransaction()
+            .setCustomAnimations(
+                R.anim.fragment_in,
+                R.anim.fragment_out,
+                R.anim.fragment_in,
+                R.anim.fragment_out
+            )
+            .add(R.id.fragment_container, EditLocaleFragment.getEditInstance(localeItem))
+            .addToBackStack(null)
+            .commit()
+    }
+
     private var adapter: LocaleListAdapter? = null
+    private var currentListItemAdapter: CurrentLocaleListAdapter? = null
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -74,37 +105,50 @@ class LocaleListFragment : Fragment(R.layout.fragment_locale_list) {
             Timber.d("Change locale ${localeItem.displayName}")
             setLocale(localeItem)
         }
+        currentListItemAdapter = CurrentLocaleListAdapter(
+            LayoutInflater.from(context),
+            currentListItemMenuCallback
+        )
     }
 
     private fun setLocale(localeItem: LocaleItem) {
-        viewModel.setLocale(localeItem)
+        viewModel.addToCurrentLocales(localeItem)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         setFragmentResultListener(EditLocaleFragment.MODE.ADD.name) { requestKey, bundle ->
-            val localeItemAdded = bundle.getParcelable<LocaleItem>(EditLocaleFragment.RESULT_KEY_LOCALE_ITEM)
+            val localeItemAdded =
+                bundle.getParcelable<LocaleItem>(EditLocaleFragment.RESULT_KEY_LOCALE_ITEM)
                     ?: return@setFragmentResultListener
             Timber.d("Fragment Result $requestKey ${localeItemAdded.displayName}")
             viewModel.addLocale(localeItemAdded)
         }
         setFragmentResultListener(EditLocaleFragment.MODE.EDIT.name) { requestKey, bundle ->
             Timber.d("Fragment Result $requestKey")
-            val localeItemEdited = bundle.getParcelable<LocaleItem>(EditLocaleFragment.RESULT_KEY_LOCALE_ITEM)
+            val localeItemEdited =
+                bundle.getParcelable<LocaleItem>(EditLocaleFragment.RESULT_KEY_LOCALE_ITEM)
                     ?: return@setFragmentResultListener
             viewModel.editLocale(localeItemEdited)
         }
         setFragmentResultListener(EditLocaleFragment.MODE.SET.name) { requestKey, bundle ->
             Timber.d("Fragment Result $requestKey")
-            val localeItem = bundle.getParcelable<LocaleItem>(EditLocaleFragment.RESULT_KEY_LOCALE_ITEM)
+            val localeItem =
+                bundle.getParcelable<LocaleItem>(EditLocaleFragment.RESULT_KEY_LOCALE_ITEM)
                     ?: return@setFragmentResultListener
             setLocale(localeItem)
         }
 
-        viewModel.currentLocale.observe(viewLifecycleOwner) { currentLocale ->
+        viewModel.currentLocales.observe(viewLifecycleOwner) { currentLocale ->
+            currentListItemAdapter?.also {
+                it.submitList(currentLocale)
+            }
+        }
+
+        viewModel.canSave.observe(viewLifecycleOwner) { canSave ->
             binding?.also {
-                it.currentLocale = currentLocale
+                it.canSave = canSave
             }
         }
 
@@ -130,14 +174,16 @@ class LocaleListFragment : Fragment(R.layout.fragment_locale_list) {
         binding = FragmentLocaleListBinding.bind(view).also { binding ->
             binding.lifecycleOwner = viewLifecycleOwner
             binding.recyclerView.layoutManager = WrapContentLinearLayoutManager(
-                    requireContext(), LinearLayoutManager.VERTICAL, false)
+                requireContext(), LinearLayoutManager.VERTICAL, false
+            )
             binding.recyclerView.adapter = adapter
-            binding.customLocale.setOnClickListener {
-                parentFragmentManager.beginTransaction()
-                        .setCustomAnimations(R.anim.fragment_in, R.anim.fragment_out, R.anim.fragment_in, R.anim.fragment_out)
-                        .add(R.id.fragment_container, EditLocaleFragment.getSetInstance(viewModel.currentLocale.value))
-                        .addToBackStack(null)
-                        .commit()
+            binding.recyclerViewCurrentLocales.layoutManager = WrapContentLinearLayoutManager(
+                requireContext(), LinearLayoutManager.VERTICAL, false
+            )
+            binding.recyclerViewCurrentLocales.adapter = currentListItemAdapter
+
+            binding.saveLocalesSettingButton.setOnClickListener {
+                viewModel.setLocales()
             }
 
             val activity = requireActivity()
@@ -146,8 +192,7 @@ class LocaleListFragment : Fragment(R.layout.fragment_locale_list) {
             }
         }
 
-        viewModel.loadCurrentLocale(requireContext())
-        viewModel.loadLocaleList(requireContext())
+        viewModel.loadLocaleListAndCurrentLocaleList(requireContext())
     }
 
     private fun setupActionBar(activity: AppCompatActivity, toolBar: Toolbar) {
@@ -164,20 +209,27 @@ class LocaleListFragment : Fragment(R.layout.fragment_locale_list) {
         when (item.itemId) {
             R.id.menu_add_locale -> {
                 parentFragmentManager.beginTransaction()
-                        .setCustomAnimations(R.anim.fragment_in, R.anim.fragment_out, R.anim.fragment_in, R.anim.fragment_out)
-                        .add(R.id.fragment_container, EditLocaleFragment.getAddInstance())
-                        .addToBackStack(null)
-                        .commit()
+                    .setCustomAnimations(
+                        R.anim.fragment_in,
+                        R.anim.fragment_out,
+                        R.anim.fragment_in,
+                        R.anim.fragment_out
+                    )
+                    .add(R.id.fragment_container, EditLocaleFragment.getAddInstance())
+                    .addToBackStack(null)
+                    .commit()
             }
+
             R.id.menu_license -> {
                 parentFragmentManager.beginTransaction()
-                        .add(R.id.fragment_container, LicenseFragment.getInstance())
-                        .addToBackStack(null)
-                        .commit()
+                    .add(R.id.fragment_container, LicenseFragment.getInstance())
+                    .addToBackStack(null)
+                    .commit()
             }
+
             R.id.menu_about -> {
                 AboutDialog.getInstance()
-                        .show(parentFragmentManager, AboutDialog.TAG)
+                    .show(parentFragmentManager, AboutDialog.TAG)
             }
         }
         return super.onOptionsItemSelected(item)

--- a/app/src/main/java/jp/co/c_lis/ccl/morelocale/ui/locale_list/LocaleListViewModel.kt
+++ b/app/src/main/java/jp/co/c_lis/ccl/morelocale/ui/locale_list/LocaleListViewModel.kt
@@ -88,21 +88,15 @@ class LocaleListViewModel @Inject constructor(
         }
     }
 
-    fun moveInCurrentLocales(localeItem: LocaleItem, isUp: Boolean) {
+    fun moveInCurrentLocales(fromPosition: Int, toPosition: Int) {
         viewModelScope.launch {
             val ls = currentLocales.value?.toMutableList() ?: mutableListOf()
-            if (!ls.contains(localeItem)) {
+            if (fromPosition < 0 || toPosition < 0 || ls.size <= fromPosition || ls.size <= toPosition) {
                 return@launch
             }
-            val idx = ls.indexOf(localeItem)
-            if (isUp && idx == 0 || (!isUp && idx >= ls.size - 1)) {
-                return@launch
-            }
-
-            val x = if (isUp) -1 else 1
-            val t = ls[idx + x]
-            ls[idx + x] = ls[idx]
-            ls[idx] = t
+            val it = ls[fromPosition]
+            ls.remove(it)
+            ls.add(toPosition, it)
             currentLocales.postValue(ls)
             checkIfCanSave(ls)
         }
@@ -110,7 +104,7 @@ class LocaleListViewModel @Inject constructor(
 
     fun loadLocaleListAndCurrentLocaleList(context: Context) {
         viewModelScope.launch {
-            val all = localeListRepository.getAll(context.assets)
+            val all = localeListRepository.getAll()
             localeList.postValue(all)
             loadCurrentLocales(context, all)
         }

--- a/app/src/main/java/jp/co/c_lis/ccl/morelocale/ui/locale_list/LocaleListViewModel.kt
+++ b/app/src/main/java/jp/co/c_lis/ccl/morelocale/ui/locale_list/LocaleListViewModel.kt
@@ -1,6 +1,7 @@
 package jp.co.c_lis.ccl.morelocale.ui.locale_list
 
 import android.content.Context
+import android.os.LocaleList
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
@@ -16,6 +17,7 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.lang.reflect.InvocationTargetException
 import javax.inject.Inject
+import jp.co.c_lis.ccl.morelocale.equals
 
 @HiltViewModel
 class LocaleListViewModel @Inject constructor(
@@ -23,26 +25,94 @@ class LocaleListViewModel @Inject constructor(
     private val preferenceRepository: PreferenceRepository,
 ) : ViewModel() {
 
-    val currentLocale = MutableLiveData<LocaleItem>()
+    private var lastCurrentLocales = listOf<LocaleItem>()
+    val currentLocales = MutableLiveData<MutableList<LocaleItem>>()
     val localeList = MutableLiveData<List<LocaleItem>>()
+    val canSave = MutableLiveData(false)
 
     private val _alertsEvents = MutableSharedFlow<AlertsMoreLocale>()
     val alertsEvents = _alertsEvents.asLiveData()
 
-    fun loadCurrentLocale(context: Context) = viewModelScope.launch {
-        val localeConfigs = createLocale(MoreLocale.getLocale(context.resources.configuration))
-        val localePreferences = preferenceRepository.loadLocale()
+    private fun loadCurrentLocales(context: Context, localeList: List<LocaleItem>) =
+        viewModelScope.launch {
+            val localeConfigs = MoreLocale.getLocale(context.resources.configuration)
+            val localePreferences = preferenceRepository.loadLocale()
 
-        if (localePreferences != null && localeConfigs.id != localePreferences.id) {
-            setLocale(localePreferences)
+            if (localePreferences != null && !equals(
+                    localeConfigs,
+                    localePreferences
+                )
+            ) {
+                setLocales(localePreferences) {}
+            }
+            val locales = localePreferences ?: localeConfigs
+            val ls = mutableListOf<LocaleItem>()
+            val ids = localeList.map { it.id }.toMutableSet()
+            for (i in 0 until locales.size()) {
+                val element = createLocale(locales[i], localeList, ids)
+                ls.add(element)
+                ids.add(element.id)
+            }
+
+            currentLocales.postValue(ls)
+            lastCurrentLocales = ls.toList()
         }
 
-        currentLocale.postValue(localePreferences ?: localeConfigs)
+    private fun checkIfCanSave(ls: MutableList<LocaleItem>) {
+        canSave.postValue(ls != lastCurrentLocales)
     }
 
-    fun loadLocaleList(context: Context) {
+    fun addToCurrentLocales(localeItem: LocaleItem) {
         viewModelScope.launch {
-            localeList.postValue(localeListRepository.getAll(context.assets))
+            val ls = currentLocales.value?.toMutableList() ?: mutableListOf()
+            if (ls.contains(localeItem)) {
+                return@launch
+            }
+
+            ls.add(0, localeItem)
+            currentLocales.postValue(ls)
+            checkIfCanSave(ls)
+        }
+    }
+
+    fun delFromCurrentLocales(localeItem: LocaleItem) {
+        viewModelScope.launch {
+            val ls = currentLocales.value?.toMutableList() ?: mutableListOf()
+            if (!ls.contains(localeItem) || ls.size < 2) {
+                return@launch
+            }
+
+            ls.remove(localeItem)
+            currentLocales.postValue(ls)
+            checkIfCanSave(ls)
+        }
+    }
+
+    fun moveInCurrentLocales(localeItem: LocaleItem, isUp: Boolean) {
+        viewModelScope.launch {
+            val ls = currentLocales.value?.toMutableList() ?: mutableListOf()
+            if (!ls.contains(localeItem)) {
+                return@launch
+            }
+            val idx = ls.indexOf(localeItem)
+            if (isUp && idx == 0 || (!isUp && idx >= ls.size - 1)) {
+                return@launch
+            }
+
+            val x = if (isUp) -1 else 1
+            val t = ls[idx + x]
+            ls[idx + x] = ls[idx]
+            ls[idx] = t
+            currentLocales.postValue(ls)
+            checkIfCanSave(ls)
+        }
+    }
+
+    fun loadLocaleListAndCurrentLocaleList(context: Context) {
+        viewModelScope.launch {
+            val all = localeListRepository.getAll(context.assets)
+            localeList.postValue(all)
+            loadCurrentLocales(context, all)
         }
     }
 
@@ -69,15 +139,27 @@ class LocaleListViewModel @Inject constructor(
         }
     }
 
-    fun setLocale(localeItem: LocaleItem) = viewModelScope.launch {
+    private fun setLocales(locales: LocaleList, whenSucceed: () -> Unit) = viewModelScope.launch {
         try {
-            MoreLocale.setLocale(localeItem.locale)
+            MoreLocale.setLocale(locales)
 
-            preferenceRepository.saveLocale(localeItem)
+            if (preferenceRepository.saveLocale(locales)) {
+                whenSucceed()
+            }
         } catch (e: InvocationTargetException) {
             Timber.e(e, "InvocationTargetException")
 
             _alertsEvents.emit(AlertsMoreLocale.NEED_PERMISSION)
+        }
+    }
+
+    fun setLocales() = viewModelScope.launch {
+        val ls: List<LocaleItem>? = currentLocales.value
+        if (!ls.isNullOrEmpty()) {
+            setLocales(LocaleList(*ls.map { it.locale }.toTypedArray())) {
+                lastCurrentLocales = ls.toList()
+                canSave.postValue(false)
+            }
         }
     }
 }

--- a/app/src/main/res/drawable/move_handler.xml
+++ b/app/src/main/res/drawable/move_handler.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24">
+
+    <path
+        android:fillColor="#aaaaaa"
+        android:pathData="M4,4.5 L20,4.5 20,7.5 4,7.5 z M4,10.5 L20,10.5 20,13.5 4,13.5 z M4,16.5 L20,16.5 20,19.5 4,19.5" />
+</vector>

--- a/app/src/main/res/layout/fragment_edit_locale.xml
+++ b/app/src/main/res/layout/fragment_edit_locale.xml
@@ -151,6 +151,24 @@
                         android:singleLine="true" />
                 </com.google.android.material.textfield.TextInputLayout>
 
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/textInputLayoutScript"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    app:layout_constraintEnd_toEndOf="@+id/textInputLayout"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/textInputLayout">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/input_script"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="@string/script"
+                        android:inputType="textNoSuggestions"
+                        android:maxLength="8"
+                        android:singleLine="true" />
+                </com.google.android.material.textfield.TextInputLayout>
             </androidx.constraintlayout.widget.ConstraintLayout>
 
         </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_locale_list.xml
+++ b/app/src/main/res/layout/fragment_locale_list.xml
@@ -72,7 +72,7 @@
                 android:layout_height="280dp"
                 android:layout_below="@id/currentLocalesHeader"
                 android:scrollbars="vertical"
-                tools:listitem="@layout/list_item_locale" />
+                tools:listitem="@layout/list_item_locale_in_current_locale" />
 
             <TextView
                 android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_locale_list.xml
+++ b/app/src/main/res/layout/fragment_locale_list.xml
@@ -6,8 +6,8 @@
     <data>
 
         <variable
-            name="currentLocale"
-            type="jp.co.c_lis.ccl.morelocale.entity.LocaleItem" />
+            name="canSave"
+            type="Boolean" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -35,33 +35,55 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:minHeight="?android:listPreferredItemHeight"
-            android:paddingStart="16dp"
-            android:paddingLeft="16dp"
-            android:paddingTop="8dp"
-            android:paddingEnd="8dp"
-            android:paddingRight="8dp"
+
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/appBarLayout">
 
-            <TextView
-                android:id="@+id/current_locale_display"
-                style="@style/TextAppearance.MaterialComponents.Body1"
-                android:layout_width="wrap_content"
+            <RelativeLayout
+                android:id="@+id/currentLocalesHeader"
+                android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:text="@{currentLocale.displayFull}"
-                tools:text="日本語（日本） ja JP N/A" />
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp">
 
-            <Button
-                android:id="@+id/custom_locale"
-                style="@style/Widget.MaterialComponents.Button.TextButton"
+                <TextView
+                    android:id="@+id/currentLocalesTitle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignBaseline="@id/saveLocalesSettingButton"
+                    android:paddingBottom="16dp"
+                    android:text="@string/current_locales_settings" />
+
+                <Button
+                    android:id="@+id/saveLocalesSettingButton"
+                    style="@style/Widget.MaterialComponents.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentEnd="true"
+                    android:layout_toEndOf="@+id/currentLocalesTitle"
+                    android:enabled="@{canSave}"
+                    android:text="@string/save" />
+            </RelativeLayout>
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerViewCurrentLocales"
+                android:layout_width="fill_parent"
+                android:layout_height="280dp"
+                android:layout_below="@id/currentLocalesHeader"
+                android:scrollbars="vertical"
+                tools:listitem="@layout/list_item_locale" />
+
+            <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_below="@+id/current_locale_display"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentRight="true"
-                android:layout_marginTop="8dp"
-                android:text="@string/set_custom_locale" />
+                android:layout_below="@id/recyclerViewCurrentLocales"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:paddingTop="16dp"
+                android:paddingBottom="16dp"
+                android:text="@string/all_locales" />
+
         </RelativeLayout>
 
         <androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/layout/list_item_locale.xml
+++ b/app/src/main/res/layout/list_item_locale.xml
@@ -37,7 +37,7 @@
             android:layout_marginEnd="8dp"
             android:layout_marginRight="8dp"
             android:gravity="center_vertical"
-            android:text="@{locale.displayName}"
+            android:text="@{locale.displayFull}"
             android:textStyle="normal"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/more"

--- a/app/src/main/res/layout/list_item_locale.xml
+++ b/app/src/main/res/layout/list_item_locale.xml
@@ -28,29 +28,57 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
+            android:id="@+id/label_langCode"
+            android:layout_width="50dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="@{locale.langCode}"
+            android:textStyle="normal"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/label"
+            app:layout_constraintStart_toEndOf="@+id/color_bar"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="zh-cn-Hans" />
+
+        <LinearLayout
+            android:orientation="vertical"
             android:id="@+id/label"
-            style="@style/TextAppearance.MaterialComponents.Body1"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:layout_marginLeft="8dp"
             android:layout_marginEnd="8dp"
             android:layout_marginRight="8dp"
-            android:gravity="center_vertical"
-            android:text="@{locale.displayFull}"
-            android:textStyle="normal"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/more"
-            app:layout_constraintStart_toEndOf="@+id/color_bar"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/label_langCode"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <TextView
+                style="@style/TextAppearance.MaterialComponents.Body1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@{locale.displayName}"
+                android:textStyle="normal"
+                tools:text="Japanese（日本）" />
+
+        <TextView
+            android:id="@+id/labelLocalName"
+            style="@style/TextAppearance.MaterialComponents.Body1"
+            android:layout_width="wrap_content"
+            android:gravity="start"
+            android:layout_height="wrap_content"
+            android:text="@{locale.displayNameInLocal}"
+            android:textStyle="normal"
             tools:text="日本語（日本）" />
+        </LinearLayout>
+
 
         <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/more"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="8dp"
-            android:layout_marginRight="8dp"
             android:background="?android:attr/selectableItemBackground"
             android:src="@drawable/more_vert"
             app:layout_constraintBottom_toBottomOf="@+id/label"

--- a/app/src/main/res/layout/list_item_locale_in_current_locale.xml
+++ b/app/src/main/res/layout/list_item_locale_in_current_locale.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="locale"
+            type="jp.co.c_lis.ccl.morelocale.entity.LocaleItem" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?android:attr/selectableItemBackground"
+        android:minHeight="?android:listPreferredItemHeight">
+
+        <View
+            android:id="@+id/color_bar"
+            android:layout_width="4dp"
+            android:layout_height="0dp"
+            android:layout_marginTop="1dp"
+            android:layout_marginBottom="1dp"
+            android:background="@{locale.preset ? @color/preset_ribbon : @color/custom_ribbon}"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/drag_handler"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:background="?android:attr/selectableItemBackground"
+            android:src="@drawable/move_handler"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/color_bar"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/label_langCode"
+            android:layout_width="50dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="@{locale.langCode}"
+            android:textStyle="normal"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/label"
+            app:layout_constraintStart_toEndOf="@+id/drag_handler"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="zh-cn-Hans" />
+
+        <LinearLayout
+            android:orientation="vertical"
+            android:id="@+id/label"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginLeft="8dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginRight="8dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/more"
+            app:layout_constraintStart_toEndOf="@+id/label_langCode"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <TextView
+                style="@style/TextAppearance.MaterialComponents.Body1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@{locale.displayName}"
+                android:textStyle="normal"
+                tools:text="Japanese（日本）" />
+
+        <TextView
+            android:id="@+id/labelLocalName"
+            style="@style/TextAppearance.MaterialComponents.Body1"
+            android:layout_width="wrap_content"
+            android:gravity="start"
+            android:layout_height="wrap_content"
+            android:text="@{locale.displayNameInLocal}"
+            android:textStyle="normal"
+            tools:text="日本語（日本）" />
+        </LinearLayout>
+
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/more"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:background="?android:attr/selectableItemBackground"
+            android:src="@drawable/more_vert"
+            app:layout_constraintBottom_toBottomOf="@+id/label"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/label" />
+
+        <View
+            android:id="@+id/divider"
+            android:layout_width="0dp"
+            android:layout_height="1px"
+            android:background="#99696969"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/menu/list_item_current_locale.xml
+++ b/app/src/main/res/menu/list_item_current_locale.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/menu_up"
+        android:title="@string/move_up" />
+
+    <item
+        android:id="@+id/menu_down"
+        android:title="@string/move_down" />
+
+<!--    <item-->
+<!--        android:id="@+id/menu_edit"-->
+<!--        android:title="@string/set_custom_locale"/>-->
+
+    <item
+        android:id="@+id/menu_delete"
+        android:title="@string/delete" />
+</menu>

--- a/app/src/main/res/menu/list_item_current_locale.xml
+++ b/app/src/main/res/menu/list_item_current_locale.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <item
-        android:id="@+id/menu_up"
-        android:title="@string/move_up" />
-
-    <item
-        android:id="@+id/menu_down"
-        android:title="@string/move_down" />
-
 <!--    <item-->
 <!--        android:id="@+id/menu_edit"-->
 <!--        android:title="@string/set_custom_locale"/>-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,4 +29,8 @@
     <string name="about_url" translatable="false">https://github.com/c-lis/morelocale</string>
     <string name="copyright" translatable="false">Copyright C-LIS CO., LTD.</string>
     <string name="search">Search</string>
+    <string name="move_down">Move Down</string>
+    <string name="move_up">Move up</string>
+    <string name="current_locales_settings">Current locales settings</string>
+    <string name="all_locales">All locales</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,4 +33,5 @@
     <string name="move_up">Move up</string>
     <string name="current_locales_settings">Current locales settings</string>
     <string name="all_locales">All locales</string>
+    <string name="script">Script</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,8 +29,6 @@
     <string name="about_url" translatable="false">https://github.com/c-lis/morelocale</string>
     <string name="copyright" translatable="false">Copyright C-LIS CO., LTD.</string>
     <string name="search">Search</string>
-    <string name="move_down">Move Down</string>
-    <string name="move_up">Move up</string>
     <string name="current_locales_settings">Current locales settings</string>
     <string name="all_locales">All locales</string>
     <string name="script">Script</string>

--- a/app/src/main/res/values/strings_help.xml
+++ b/app/src/main/res/values/strings_help.xml
@@ -1,9 +1,13 @@
 <resources>
     <string name="permission_required">Permission required</string>
     <string name="permission_required_message">MoreLocale is not granted a CHANGE_CONFIGURATION permission.\nIf you\'re able to use development tools, you can grant the permission manually by \'pm\' command.\n\nIf you have SuperUser privilege on your device.\nMoreLocale could get the permission automatically.</string>
+    <string name="permission_required_message_extra_permission">MoreLocale is not granted a CHANGE_CONFIGURATION and a WRITE_SETTINGS permission.\nIf you\'re able to use development tools, you can grant the permission manually by \'pm\' command.\n\nIf you have SuperUser privilege on your device.\nMoreLocale could get the permission automatically.</string>
     <string name="use_pm_command">Use \'pm\' command</string>
     <string name="execute_as_su">Execute as SuperUser</string>
     <string name="use_pm_command_message">1. On <b>Develop Options</b> enable <b>USB debugging mode</b> and <b>Disable Permission Monitoring</b> if available.\n2. Connect the device to your PC and type command below.\n<b>adb shell pm grant jp.co.c_lis.ccl.morelocale android.permission.CHANGE_CONFIGURATION</b></string>
     <string name="permission_granted">Permission is granted.</string>
     <string name="could_not_get_su_privilege">Couldn\'t get SuperUser privilege…</string>
+    <string name="click_to_copy_the_command">Click to copy the command</string>
+    <string name="already_copy_the_command">Already copy the command</string>
+    <string name="go_to_settings">Go to settings to grant WRITE_SETTINGS permission</string>
 </resources>

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -7,7 +7,7 @@ android {
 
     compileSdk = 34
     defaultConfig {
-        minSdk = 19
+        minSdk = 24
     }
 
     buildFeatures {

--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
     <uses-permission
         android:name="android.permission.CHANGE_CONFIGURATION"
         tools:ignore="ProtectedPermissions" />
+    <uses-permission android:name="android.permission.WRITE_SETTINGS"
+        tools:ignore="ProtectedPermissions"/>
     <uses-permission android:name="com.google.android.glass.permission.DEVELOPMENT" />
 
     <application />

--- a/lib/src/main/java/jp/co/c_lis/morelocale/MoreLocale.java
+++ b/lib/src/main/java/jp/co/c_lis/morelocale/MoreLocale.java
@@ -34,14 +34,12 @@ package jp.co.c_lis.morelocale;
 
 import android.annotation.SuppressLint;
 import android.content.res.Configuration;
-import android.os.Build;
 import android.os.LocaleList;
 import android.util.Log;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Locale;
 
 public class MoreLocale {
     private static final String LOG_TAG = MoreLocale.class.getSimpleName();
@@ -68,26 +66,17 @@ public class MoreLocale {
      *
      * @return Locale
      */
-    @SuppressWarnings("deprecation")
-    public static Locale getLocale(Configuration configuration) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            return configuration.getLocales().get(0);
-        } else {
-            return configuration.locale;
-        }
+    public static LocaleList getLocale(Configuration configuration) {
+        return configuration.getLocales();
     }
 
     /**
      * 言語を設定.
      *
-     * @param locale
+     * @param locales
      */
-    public static boolean setLocale(Locale locale) throws InvocationTargetException {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            return setLocaleList(new LocaleList(locale));
-        } else {
-            return setSingleLocale(locale);
-        }
+    public static boolean setLocale(LocaleList locales) throws InvocationTargetException {
+        return setLocaleList(locales);
     }
 
     /**
@@ -114,7 +103,7 @@ public class MoreLocale {
             setUserSetLocale(config, true);
 
             // am.updateConfiguration(config);
-            Method updateConfiguration = am.getClass().getMethod("updateConfiguration", new Class[]{Configuration.class});
+            Method updateConfiguration = am.getClass().getMethod("updatePersistentConfiguration", new Class[]{Configuration.class});
             updateConfiguration.invoke(am, new Object[]{config});
 
             return true;
@@ -134,48 +123,4 @@ public class MoreLocale {
         }
         return false;
     }
-
-    /**
-     * 言語を設定
-     *
-     * @param locale
-     */
-    @SuppressWarnings({"RedundantArrayCreation", "ConfusingArgumentToVarargsMethod"})
-    private static boolean setSingleLocale(Locale locale) throws InvocationTargetException {
-        try {
-            @SuppressLint("PrivateApi") Class<?> activityManagerNative = Class.forName("android.app.ActivityManagerNative");
-
-            // ActivityManagerNative.getDefault();
-            Method getDefault = activityManagerNative.getMethod("getDefault", null);
-            Object am = getDefault.invoke(activityManagerNative, null);
-
-            // am.getConfiguration();
-            Method getConfiguration = am.getClass().getMethod("getConfiguration", null);
-            Configuration config = (Configuration) getConfiguration.invoke(am, null);
-
-            config.locale = locale;
-            setUserSetLocale(config, true);
-
-            // am.updateConfiguration(config);
-            Method updateConfiguration = am.getClass().getMethod("updateConfiguration", new Class[]{Configuration.class});
-            updateConfiguration.invoke(am, new Object[]{config});
-
-            return true;
-
-        } catch (ClassNotFoundException e) {
-            if (BuildConfig.DEBUG) {
-                Log.e(LOG_TAG, "ClassNotFoundException", e);
-            }
-        } catch (NoSuchMethodException e) {
-            if (BuildConfig.DEBUG) {
-                Log.e(LOG_TAG, "NoSuchMethodException", e);
-            }
-        } catch (IllegalAccessException e) {
-            if (BuildConfig.DEBUG) {
-                Log.e(LOG_TAG, "IllegalAccessException", e);
-            }
-        }
-        return false;
-    }
-
 }


### PR DESCRIPTION
Implement #19 

Change to support set multiple locals/languages. This enables the phones which cannot set multiple languages in system settings to do so. 

Tested on Xiaomi HyperOS 1, android 14

![Screenshot_2024-08-01-22-29-18-542_jp co c_lis ccl morelocale](https://github.com/user-attachments/assets/96ca1dd5-d0f8-4e7c-9264-389726ca5018)

However, 
1. minSdk will be updated to 24, as version lower than 24 can not initialize a `LocaleList`.
2. A new permission `android.permission.WRITE_SETTINGS` will be needed. And I don't know whether this permission can be granted by root, so I just make a button to jump to the settings. 

![图片](https://github.com/user-attachments/assets/f5481d10-2647-447f-b700-886d8c689941)
